### PR TITLE
let auxiliary integer as in sqisign2d spec

### DIFF
--- a/sage_implementation/precomputations.py
+++ b/sage_implementation/precomputations.py
@@ -6,7 +6,7 @@ from sage.all import(
     matrix, vector,
     QuaternionAlgebra,
     randint, is_prime,
-    gcd
+    gcd, next_prime
 )
 
 from sqisign2d_west.endomorphisms import FullrepresentInteger, iota
@@ -34,7 +34,7 @@ class Precomputations:
         self.e = e
         self.D = D
         self.tate_exp = (p**2 - 1) // D
-        self.aux_integer = D #auxiliary integer for random_ideal_of_given_norm
+        self.aux_integer = next_prime(ZZ(1) << p.bit_length(), proof=False) #auxiliary integer for random_ideal_of_given_norm
 
         ## Isogenies:
         # Do we need extra available torsion for our isogenies?


### PR DESCRIPTION
Issue: The method `Precomputations.random_ideal_of_given_norm` sometimes fails when called with small degrees. 

In the code, the attribute `aux_integer` of instances of the `Precomputations` class was set to $2^a$ where $p+1 = f \cdot 2^a$.
According to the [SQISign specification](https://csrc.nist.gov/csrc/media/Projects/pqc-dig-sig/documents/round-2/spec-files/sqisign-spec-round2-web.pdf), `aux_integer` should mirror the quantity `QUAT_prime_cofactor` (see page 104 in the spec).

I changed the code to fix this attribute following the spec.