### PR TITLE
allow smaller s in FixedDegreeIsogeny

### DIFF
--- a/sage_implementation/sqisign2d_west/fixed_degree_isogeny.py
+++ b/sage_implementation/sqisign2d_west/fixed_degree_isogeny.py
@@ -26,9 +26,8 @@ class FixedDegreeIsogeny:
         P0, Q0 = precomps.basis
 
         # TODO: choice?
-        s = ceil(p/u +u).nbits() + 25
-        assert s<=e
-        #s = min(s,e)
+        s = ceil(p/u + u).nbits() + 25
+        s = min(s, self.e_target)
         a, b, c, d = FullrepresentInteger(u * (2 ** s - u), p, TrulyRandom = self.TrulyRandom)
 
         self.s = s


### PR DESCRIPTION
Calling FixedDegreeIsogeny in use cases outside of PRISM or SQIsign, it might happen that the assertion `s <= e` isn't satisfied.

If `s` is set to be `min(s, self.e_target)`, then the 2D-isogeny that is built has enough rational torsion, right?
In the previous use cases, I believe this shouldn't cause problems since `s` was already smaller than the available torsion.