### PR TITLE
[bugfix] remove c from precomputation arguments

### DIFF
--- a/sage_implementation/PRISM_id.py
+++ b/sage_implementation/PRISM_id.py
@@ -34,7 +34,7 @@ class PRISM_id:
             type(x).vector_space = cached_method(type(x).vector_space)
         self.id_torsion = params.id_torsion
         if not precomps:
-            precomps = Precomputations(p, 122, role = role)
+            precomps = Precomputations(p, role = role)
         self.precomps = precomps
 
     def keygen(self):
@@ -122,7 +122,6 @@ class PRISM_id:
         """
 
         precomps=self.precomps
-        # c = precomps.c
         e = precomps.e
 
         # Computing the isogeny associated with the ideal Isk

--- a/sage_implementation/PRISM_sign.py
+++ b/sage_implementation/PRISM_sign.py
@@ -46,7 +46,7 @@ class PRISM_sign:
         for x in to_patch:
             type(x).vector_space = cached_method(type(x).vector_space)
         if not precomps:
-            precomps = Precomputations(p, 122, role = role, a = 'max')
+            precomps = Precomputations(p, role = role, a = 'max')
         self.precomps = precomps
 
     def keygen(self):
@@ -140,7 +140,6 @@ class PRISM_sign:
         """
 
         precomps=self.precomps
-        # c = precomps.c
         a = precomps.e
 
         # Computing the isogeny associated with the ideal Isk

--- a/sage_implementation/precomputations.py
+++ b/sage_implementation/precomputations.py
@@ -22,7 +22,7 @@ from montgomery_isogenies.kummer_line import KummerLine
 
 
 class Precomputations:
-    def __init__(self, p, c, role='signer', a = 'max'):
+    def __init__(self, p, role='signer', a = 'max'):
         self.p = ZZ(p)
         self.c = c
         e = (self.p + 1).valuation(2)


### PR DESCRIPTION
Bug: in `ideal_to_isogeny_clapotis.py`, the init function calls `Precomputations(p)`.
However, `Precomputations` now requires an extra argument `c`; it's set to be `122` in some places in the code, otherwise never used.

I'd suggest removing this argument.